### PR TITLE
ENH: Add answer keys for each fib exercise.

### DIFF
--- a/exercises/fib/fib/fib-abstract-api-extra.c
+++ b/exercises/fib/fib/fib-abstract-api-extra.c
@@ -1,0 +1,97 @@
+#include <Python.h>
+
+static unsigned long
+cfib(unsigned long n)
+{
+    unsigned long a = 1;
+    unsigned long b = 1;
+    unsigned long c;
+
+    if (n <= 1) {
+        return 1;
+    }
+
+    while (--n > 1) {
+        c = a + b;
+        a = b;
+        b = c;
+    }
+
+    return b;
+}
+
+PyDoc_STRVAR(fib_doc, "compute the nth Fibonacci number");
+
+static PyObject*
+pyfib(PyObject* self, PyObject* n)
+{
+    PyObject* a = NULL;
+    PyObject* b = NULL;
+    PyObject* c;
+
+    unsigned long n_as_unsigned_long = PyLong_AsUnsignedLong(n);
+    if (PyErr_Occurred()) {
+        return NULL;
+    }
+
+    if (!(a = PyLong_FromUnsignedLong(1))) {
+        return NULL;
+    }
+
+    if (n_as_unsigned_long == 0) {
+        return a;
+    }
+
+    if (n_as_unsigned_long < 93) {
+        PyObject* result = PyLong_FromUnsignedLong(cfib(n_as_unsigned_long));
+        if (PyErr_Occurred()) {
+            return NULL;
+        }
+        return result;
+    }
+
+    if (!(b = PyLong_FromUnsignedLong(1))) {
+        Py_DECREF(a);
+        return NULL;
+    }
+
+    while (--n_as_unsigned_long > 1) {
+        c = PyNumber_Add(a, b);
+        Py_DECREF(a);
+
+        if (!c) {
+            Py_DECREF(b);
+            return NULL;
+        }
+
+        a = b;
+        b = c;
+    }
+    Py_DECREF(a);
+    return b;
+}
+
+PyMethodDef methods[] = {
+    {"fib", (PyCFunction) pyfib, METH_O, fib_doc},
+    {NULL},
+};
+
+PyDoc_STRVAR(fib_module_doc, "provides a Fibonacci function");
+
+PyModuleDef fib_module = {
+    PyModuleDef_HEAD_INIT,
+    "fib",
+    fib_module_doc,
+    -1,
+    methods,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
+
+PyMODINIT_FUNC
+PyInit_fib(void)
+{
+    return PyModule_Create(&fib_module);
+}

--- a/exercises/fib/fib/fib-abstract-api.c
+++ b/exercises/fib/fib/fib-abstract-api.c
@@ -1,0 +1,69 @@
+#include <Python.h>
+
+PyDoc_STRVAR(fib_doc, "compute the nth Fibonacci number");
+
+static PyObject*
+pyfib(PyObject* self, PyObject* n)
+{
+    PyObject* a = NULL;
+    PyObject* b = NULL;
+    PyObject* c;
+
+    unsigned long n_as_unsigned_long = PyLong_AsUnsignedLong(n);
+    if (PyErr_Occurred()) {
+        return NULL;
+    }
+
+    if (!(a = PyLong_FromUnsignedLong(1))) {
+        return NULL;
+    }
+
+    if (n_as_unsigned_long == 0) {
+        return a;
+    }
+
+    if (!(b = PyLong_FromUnsignedLong(1))) {
+        Py_DECREF(a);
+        return NULL;
+    }
+
+    while (--n_as_unsigned_long > 1) {
+        c = PyNumber_Add(a, b);
+        Py_DECREF(a);
+
+        if (!c) {
+            Py_DECREF(b);
+            return NULL;
+        }
+
+        a = b;
+        b = c;
+    }
+    Py_DECREF(a);
+    return b;
+}
+
+PyMethodDef methods[] = {
+    {"fib", (PyCFunction) pyfib, METH_O, fib_doc},
+    {NULL},
+};
+
+PyDoc_STRVAR(fib_module_doc, "provides a Fibonacci function");
+
+PyModuleDef fib_module = {
+    PyModuleDef_HEAD_INIT,
+    "fib",
+    fib_module_doc,
+    -1,
+    methods,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
+
+PyMODINIT_FUNC
+PyInit_fib(void)
+{
+    return PyModule_Create(&fib_module);
+}

--- a/exercises/fib/fib/fib-error-handling.c
+++ b/exercises/fib/fib/fib-error-handling.c
@@ -1,0 +1,60 @@
+#include <Python.h>
+
+static unsigned long
+cfib(unsigned long n)
+{
+    unsigned long a = 1;
+    unsigned long b = 1;
+    unsigned long c;
+
+    if (n <= 1) {
+        return 1;
+    }
+
+    while (--n > 1) {
+        c = a + b;
+        a = b;
+        b = c;
+    }
+
+    return b;
+}
+
+PyDoc_STRVAR(fib_doc, "compute the nth Fibonacci number");
+
+static PyObject*
+pyfib(PyObject* self, PyObject* n)
+{
+    unsigned long as_unsigned_long = PyLong_AsUnsignedLong(n);
+    if (PyErr_Occurred()) {
+        return NULL;
+    }
+
+    PyObject* result = PyLong_FromUnsignedLong(cfib(as_unsigned_long));
+    return result;
+}
+
+PyMethodDef methods[] = {
+    {"fib", (PyCFunction) pyfib, METH_O, fib_doc},
+    {NULL},
+};
+
+PyDoc_STRVAR(fib_module_doc, "provides a Fibonacci function");
+
+PyModuleDef fib_module = {
+    PyModuleDef_HEAD_INIT,
+    "fib",
+    fib_module_doc,
+    -1,
+    methods,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
+
+PyMODINIT_FUNC
+PyInit_fib(void)
+{
+    return PyModule_Create(&fib_module);
+}


### PR DESCRIPTION
To show path from fib.c -> fib-complete.c, add example files which show the
answers to the exercises for error handling and using the number API.

Each answer key file attempts to minimize the amount of edits needed between the
exercises leading up to the completed fib example.

Intended order of fib examples is:
- fib.c
- fib-error-handling.c
- fib-abstract-api.c
- fib-complete.c

fib-abstract-api-extra.c shows using the fibc function for the values of n which
do not result in a overflow when computing fib(n).